### PR TITLE
Fix control file and KVERS substitutions

### DIFF
--- a/module/configure.sh
+++ b/module/configure.sh
@@ -20,9 +20,9 @@ if [[ -z "$KVERS" ]]; then
 	export KVERS=$(uname -r)
 fi
 
-sed "s/@@KVERS@@/$KVERS/" \
+sed "s/@@KVERS@@/$KVERS/g" \
 	debian/control.in >debian/control
-sed "s/@@KVERS@@/$KVERS/" \
+sed "s/@@KVERS@@/$KVERS/g" \
 	debian/install.in >debian/install
-sed "s/@@KVERS@@/$KVERS/" \
+sed "s/@@KVERS@@/$KVERS/g" \
 	src/Makefile.in >src/Makefile

--- a/module/debian/control.in
+++ b/module/debian/control.in
@@ -23,8 +23,6 @@ Standards-Version: 4.1.2
 
 Package: connstat-module-@@KVERS@@
 Architecture: any
-Replaces: base-files
-Depends: ${misc:Depends}
 Description: Connstat
   This package provides advanced per-connection tcp stats.
 Provides: connstat-module


### PR DESCRIPTION
**DESCRIPTION**
- Fix the control file which has some left-overs from the template control file from delphix-platform.
- KVERS substitutions should apply to all mentions of KVERS in a file.

**TESTING**
- linux-pkg build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/1
- pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/285
