### PR TITLE
Eliminate duplicate entries

### DIFF
--- a/usr/cmd/connstat
+++ b/usr/cmd/connstat
@@ -115,8 +115,10 @@ def loopback_skip(line_str_list):
 #
 def connstat_regurgitate():
     headings_line = True
-    for line in open('/proc/net/stats_tcp'):
-        line_str_list = line.strip().split(',')
+    table_str = ""
+    for line_in in open('/proc/net/stats_tcp'):
+        line_str_list = line_in.strip().split(',')
+        line_out = ""
 
         # Omit headings(first) line for parsable output
         if args.parsable and headings_line:
@@ -132,18 +134,21 @@ def connstat_regurgitate():
         # Print selected fields using specified format
         if args.parsable:
             first_field = True
-            output = ''
             for f in output_fields:
                 if not first_field:
-                    output += ','
-                output += line_str_list[f.index]
+                    line_out += ','
+                line_out += line_str_list[f.index]
                 first_field = False
-            print (output)
         else:
             for f in output_fields:
-                format = '%' + str(f.print_width) + 's'
-                print (format % (line_str_list[f.index]), end="")
-            print()
+                sformat = "{: >" + str(f.print_width) + "}"
+                line_out += sformat.format(line_str_list[f.index], format)
+
+	# Ignore duplicate lines
+        if not line_out in table_str:
+            table_str += line_out + '\n'
+
+    return table_str
 
 parser = argparse.ArgumentParser(prog='connstat')
 
@@ -205,17 +210,17 @@ if args.parsable:
     if args.FIELDS == 'all':
         raise ValueError('\'-o all\' is invalid with parsable output')
 
+lazy_load_module()
 
 while True:
+    output = ""
     if args.TYPE is 'u':
-        print ("=", end =" ")
-        print (time.time())
+        output += "= " + str(time.time()) + "\n"
     elif args.TYPE is 'd':
-        print ("=", end =" ")
-        os.system("date")
+        output += "= " + str(os.system("data")) + "\n"
 
-    lazy_load_module()
-    connstat_regurgitate()
+    output += connstat_regurgitate()
+    print (output, end="")
 
     if args.SECONDS is None:
         break


### PR DESCRIPTION
As reported in Delphix issue DLPX-61904, the output from the connstat command sometimes contains duplicate entries.  Running a modified version of the script with extra logging verified that the duplicate entries are read from /proc/net/stats_tcp.   It appears that the root cause of the duplicate is in linx/net/ipv4/tcp_ivp4.c, which calls the connstat module code to ouput a line for each connection.  Duplicates entries can be eliminated in the connstat script.  

Additionally, the code has been modified to build an internal string containing the output for each time interval (there is one  without -i) and write that out with one print statement.   This string was needed to search for duplicates but it also seem like this approach may be better to reduce IO buffering issues.  