### PR TITLE
Leverage Vagrant for development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 *.buildinfo
 *.changes
 *.deb
+
+.vagrant
+*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provision "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -q
+    apt-get install -q -y \
+      -o Dpkg::Options::="--force-confdef" \
+      -o Dpkg::Options::="--force-confold" \
+      ansible git
+
+    ansible-playbook /vagrant/bootstrap/playbook.yml
+  SHELL
+
+  config.vm.define :bionic, autostart: false do |bionic|
+    bionic.vm.box = "ubuntu/bionic64"
+  end
+
+  config.vm.define :cosmic, autostart: false do |cosmic|
+    cosmic.vm.box = "ubuntu/cosmic64"
+  end
+end

--- a/bootstrap/roles/connstat.bootstrap/tasks/main.yml
+++ b/bootstrap/roles/connstat.bootstrap/tasks/main.yml
@@ -18,6 +18,7 @@
 - apt:
     name:
       - debhelper
+      - devscripts
       - dpkg-dev
       - libelf-dev
       - make


### PR DESCRIPTION
This change adds a "Vagrantfile" such that a developer with Vagrant
configured on their local workstation can easily set up a development VM
based on either Ubuntu's "bionic" or "cosmic" releases.

For example, to build on a "bionic" VM, once can run the following

    (workstation) $ vagrant up bionic
    (workstation) $ vagrant ssh bionic
    (vm) $ cd /vagrant && make package

Similarly, one can build on a "cosmic" VM with the following:

    (workstation) $ vagrant up cosmic
    (workstation) $ vagrant ssh cosmic
    (vm) $ cd /vagrant && make package

Finally, these VMs can be destroyed with the following command:

    (workstation) $ vagrant destroy -f