### PR TITLE
Build failure when KVERS environmental variable set

### DIFF
--- a/module/configure.sh
+++ b/module/configure.sh
@@ -24,12 +24,12 @@
 #
 if [[ -z "$KVERS" ]]; then
 	export KVERS=$(uname -r)
-	export KCENTEVERS=$(echo 100*`uname -r | cut -f1 -d.`+`uname -r | cut -f2 -d.` | bc)
 fi
+kcentevers=$(echo 100*`echo $KVERS | cut -f1 -d.`+`echo $KVERS | cut -f2 -d.` | bc)
 
 sed "s/@@KVERS@@/$KVERS/g" \
 	debian/control.in >debian/control
 sed "s/@@KVERS@@/$KVERS/g" \
 	debian/install.in >debian/install
-sed "s/@@KVERS@@/$KVERS/g; s/@@KCENTEVERS@@/$KCENTEVERS/g" \
+sed "s/@@KVERS@@/$KVERS/g; s/@@KCENTEVERS@@/$kcentevers/g" \
 	src/Makefile.in >src/Makefile

--- a/usr/cmd/connstat
+++ b/usr/cmd/connstat
@@ -225,7 +225,7 @@ while True:
     if args.TYPE is 'u':
         output += "= " + str(time.time()) + "\n"
     elif args.TYPE is 'd':
-        output += "= " + str(os.system("data")) + "\n"
+        output += "= " + str(os.system("date")) + "\n"
 
     output += connstat_regurgitate()
     print (output, end="")


### PR DESCRIPTION
Addresses: https://github.com/delphix/connstat/issues/11

Testing:
I had a discussion with Pavel on testing of connstat changes to insure the linux build is not broken.  What I did could be adopted as standard procedure for connstat PR. 

1)  I tested the linux package build on a 10.4 bootstrap machine from my github repo:
ubuntu@ip-10-110-245-255:$ git clone https://github.com/delphix/linux-pkg.git
ubuntu@ip-10-110-245-255:$ cd linux-pkg
ubuntu@ip-10-110-245-255:$ ./setup.sh
ubuntu@ip-10-110-245-255:$ ../buildpkg.sh -g https://github.com/brad-lewis/connstat.git -b custum_kvers connstat
...
Success: Package connstat has been built successfully.
Build products are in /home/ubuntu/linux-pkg/packages/connstat/tmp/artifacts

ubuntu@ip-10-110-245-255:~/linux-pkg$ ls /home/ubuntu/linux-pkg/packages/connstat/tmp/artifacts
connstat-module-4.15.0-1027-gcp_1.0.0-delphix-2019.02.22.22_amd64.deb
connstat-module-4.15.0-1029-kvm_1.0.0-delphix-2019.02.22.22_amd64.deb
connstat-module-4.15.0-1032-aws_1.0.0-delphix-2019.02.22.22_amd64.deb
connstat-module-4.15.0-45-generic_1.0.0-delphix-2019.02.22.22_amd64.deb
connstat-module-4.18.0-1011-azure_1.0.0-delphix-2019.02.22.22_amd64.deb
connstat-util_1.0.0-delphix-2019.02.22.22_amd64.deb

Notice 4.15 and 4.18 packages have been built. 

2) Since none of those packages would install on the bootstrap machine I did a local build using  the instructions on connstat page and ran the sanity tests(which initially had a typo bug).
ubuntu@ip-10-110-245-255:~/connstat/usr/cmd$ /usr/share/connstat/test/connstat_test.ksh
Testing /usr/bin/connstat
Testing /usr/bin/connstat -b
Testing /usr/bin/connstat -h
Testing /usr/bin/connstat -e
Testing /usr/bin/connstat -L
Testing /usr/bin/connstat -F badf=3
Testing /usr/bin/connstat -F lport=22
Testing /usr/bin/connstat -F lport=22 -o
Testing /usr/bin/connstat -F lport=22 -o laddr,bado
Testing /usr/bin/connstat -F lport=22 -o all
Testing /usr/bin/connstat -F lport=22 -o laddr,lport,cwnd,inbytes,outbytes
Testing /usr/bin/connstat -P
Testing /usr/bin/connstat -F lport=22 -o laddr,lport,cwnd,inbytes,outbytes -P
Testing /usr/bin/connstat -F lport=22 -c
Testing /usr/bin/connstat -F lport=22 -c 2
Testing /usr/bin/connstat -F lport=22 -i
Testing /usr/bin/connstat -F lport=22 -i 0
Testing /usr/bin/connstat -F lport=22 -i 5 -c
Testing /usr/bin/connstat -F lport=22 -i 5 -c 0
Testing /usr/bin/connstat -F lport=22 -i 5 -c 2
Testing /usr/bin/connstat -F lport=22 -T
Testing /usr/bin/connstat -F lport=22 -T a
Testing /usr/bin/connstat -F lport=22 -T u
Testing /usr/bin/connstat -F lport=22 -T d
Testing /usr/bin/connstat -F lport=22 -i 5 -c 2 -T d
Testing /usr/bin/connstat --help
Testing /usr/bin/connstat --established
Testing /usr/bin/connstat --no-loopback
Testing /usr/bin/connstat --filter badf=3
Testing /usr/bin/connstat --filter lport=22
Testing /usr/bin/connstat --filter lport=22 --output
Testing /usr/bin/connstat --filter lport=22 --output laddr,bado
Testing /usr/bin/connstat --filter lport=22 --output all
Testing /usr/bin/connstat --filter lport=22 --output laddr,lport,cwnd,inbytes,outbytes
Testing /usr/bin/connstat --parsable
Testing /usr/bin/connstat --filter lport=22 --output laddr,lport,cwnd,inbytes,outbytes --parsable
Testing /usr/bin/connstat --filter lport=22 --count
Testing /usr/bin/connstat --filter lport=22 --count 2
Testing /usr/bin/connstat --filter lport=22 --interval
Testing /usr/bin/connstat --filter lport=22 --interval 0
Testing /usr/bin/connstat --filter lport=22 --interval 5 --count
Testing /usr/bin/connstat --filter lport=22 --interval 5 --count 0
Testing /usr/bin/connstat --filter lport=22 --interval 5 --count 2
Testing /usr/bin/connstat --filter lport=22 --timestamp
Testing /usr/bin/connstat --filter lport=22 --timestamp a
Testing /usr/bin/connstat --filter lport=22 --timestamp u
Testing /usr/bin/connstat --filter lport=22 --timestamp d
Testing /usr/bin/connstat --filter lport=22 --interval 5 --count 2 --timestamp d
TEST PASSED: connstat_test.ksh

3)  I started a git-ab-pre-push run from my local connstat branch :
sysadmins-MacBook-Pro-3:module blewis$ git-ab-pre-push
Detected linux-pkg package: connstat
Waiting for build to start...
Your build is at: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/553/

 





