### PR TITLE
connstat suna column doesn't seem to represent send+unacknowledged data

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,19 @@
+name: Python Lint
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: flake8
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        flake8 usr/cmd/connstat --show-source --statistics

--- a/module/src/connstat.c
+++ b/module/src/connstat.c
@@ -11,134 +11,133 @@
  */
 
 #include <net/tcp.h>
+#include <linux/inet.h>
 #include <linux/proc_fs.h>
 
-typedef char ipv4_ip[15];
-
-#define GET_OCTET0(hip) (hip & 0xFF)
-#define GET_OCTET1(hip) ((hip>>8) & 0xFF)
-#define GET_OCTET2(hip) ((hip>>16) & 0xFF)
-#define GET_OCTET3(hip) (hip>>24)
-
-static char *tcp_state_strings[] = {
-    "NONE",
-    "ESTABLISHED",
-    "SYN_SENT",
-    "SYN_RECEIVED",
-    "FIN_WAIT1",
-    "FIN_WAIT2",
-    "TIME_WAIT",
-    "CLOSED",
-    "CLOSE_WAIT",
-    "LAST_ACK",
-    "LISTEN",
-    "CLOSING",
-    "NEW_SYN_RECV",
-    "MAX_STATES"
+struct connstat_data {
+	__be32 laddr;
+	__be32 raddr;
+	__u16 lport;
+	__u16 rport;
+	int state;
+	u32 cwnd;
+	u32 rwnd;
+	u32 swnd;
+	u32 mss;
+	u32 insegs;
+	u32 outsegs;
+	u32 retranssegs;
+	u32 rto;
+	u32 rtt;
+	u32 suna;
+	u32 unsent;
+	u32 rxqueue;
+	u64 inbytes;
+	u64 outbytes;
 };
 
-/* Convert hex ip to ipv4(XXX.XXX.XXX.XXX) */
-void hex_to_ipv4_ip(__be32 hip, ipv4_ip v4ip)
+#define GET_OCTET0(hip) (hip & 0xFF)
+#define GET_OCTET1(hip) ((hip >> 8) & 0xFF)
+#define GET_OCTET2(hip) ((hip >> 16) & 0xFF)
+#define GET_OCTET3(hip) (hip >> 24)
+
+static char *tcp_state_strings[] = {
+	"NONE",	     "ESTABLISHED", "SYN_SENT",	    "SYN_RECEIVED", "FIN_WAIT1",
+	"FIN_WAIT2", "TIME_WAIT",   "CLOSED",	    "CLOSE_WAIT",   "LAST_ACK",
+	"LISTEN",    "CLOSING",	    "NEW_SYN_RECV", "MAX_STATES"
+};
+
+/* Print an IPv4 address into the provided string and return that string. */
+static char *ipv4_ntop(__be32 addr, char *addrstr)
 {
-	sprintf(v4ip,"%d.%d.%d.%d", GET_OCTET0(hip), GET_OCTET1(hip),
-	    GET_OCTET2(hip), GET_OCTET3(hip));
+	snprintf(addrstr, INET_ADDRSTRLEN, "%d.%d.%d.%d", GET_OCTET0(addr),
+		 GET_OCTET1(addr), GET_OCTET2(addr), GET_OCTET3(addr));
+	return addrstr;
 }
 
-static void record_ipv4_route(struct seq_file *f, __be32 src,
-    __u16 srcp, __be32 dest, __u16 destp, int state, u32 cwnd, u32 rwnd,
-    u32 swnd, u32 mss, u64 inbytes, u32 insegs, u64 outbytes, u32 outsegs,
-    u32 retranssegs, u32 rto, u32 rtt, u32 suna, u32 unsent)
+static void record_ipv4_conn(struct seq_file *f, struct connstat_data *data)
 {
-	ipv4_ip laddr, raddr;
+	char laddr[INET_ADDRSTRLEN], raddr[INET_ADDRSTRLEN];
 
-	hex_to_ipv4_ip(src, laddr);
-	hex_to_ipv4_ip(dest, raddr);
-
-        seq_printf(f, "%s,%u,%s,%u,%s,%llu,%u,%llu,%u,%u,"
-	    "%u,%u,%u,%u,%u,%u,%u,%u",
-	    laddr, srcp, raddr, destp, tcp_state_strings[state],
-	    inbytes, insegs, outbytes, outsegs, retranssegs,
-	    suna, unsent, swnd, cwnd, rwnd, mss, rto, rtt);
+	seq_printf(f,
+		   "%s,%u,%s,%u,%s,%llu,%u,%llu,%u,%u,"
+		   "%u,%u,%u,%u,%u,%u,%u,%u,%u",
+		   ipv4_ntop(data->laddr, laddr), data->lport,
+		   ipv4_ntop(data->raddr, raddr), data->rport,
+		   tcp_state_strings[data->state], data->inbytes, data->insegs,
+		   data->outbytes, data->outsegs, data->retranssegs, data->suna,
+		   data->unsent, data->swnd, data->cwnd, data->rwnd, data->mss,
+		   data->rto, data->rtt, data->rxqueue);
 }
 
-
-static void get_openreq4(const struct request_sock *req,
-                         struct seq_file *f)
+static void get_openreq4(const struct request_sock *req, struct seq_file *f)
 {
-        const struct inet_request_sock *ireq = inet_rsk(req);
+	const struct inet_request_sock *ireq = inet_rsk(req);
+	struct connstat_data data = { 0 };
 
-	record_ipv4_route(f, ireq->ir_loc_addr, ireq->ir_num,
-	    ireq->ir_rmt_addr, ntohs(ireq->ir_rmt_port), TCP_SYN_RECV, 0, 0,
-	    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	data.laddr = ireq->ir_loc_addr;
+	data.raddr = ireq->ir_rmt_addr;
+	data.lport = ireq->ir_num;
+	data.rport = ntohs(ireq->ir_rmt_port);
+	data.state = TCP_SYN_RECV;
 
+	record_ipv4_conn(f, &data);
 }
 
 static void get_tcp4_sock(struct sock *sk, struct seq_file *f)
 {
-        int timer_active;
-        unsigned long timer_expires;
-        const struct tcp_sock *tp = tcp_sk(sk);
-        const struct inet_connection_sock *icsk = inet_csk(sk);
-        const struct inet_sock *inet = inet_sk(sk);
-        __be32 dest = inet->inet_daddr;
-        __be32 src = inet->inet_rcv_saddr;
-        __u16 destp = ntohs(inet->inet_dport);
-        __u16 srcp = ntohs(inet->inet_sport);
-        int rx_queue;
-        int state;
+	const struct tcp_sock *tp = tcp_sk(sk);
+	const struct inet_connection_sock *icsk = inet_csk(sk);
+	const struct inet_sock *inet = inet_sk(sk);
+	struct connstat_data data = { 0 };
 
-        if (icsk->icsk_pending == ICSK_TIME_RETRANS ||
-            icsk->icsk_pending == ICSK_TIME_REO_TIMEOUT ||
-            icsk->icsk_pending == ICSK_TIME_LOSS_PROBE) {
-                timer_active    = 1;
-                timer_expires   = icsk->icsk_timeout;
-        } else if (icsk->icsk_pending == ICSK_TIME_PROBE0) {
-                timer_active    = 4;
-                timer_expires   = icsk->icsk_timeout;
-        } else if (timer_pending(&sk->sk_timer)) {
-                timer_active    = 2;
-                timer_expires   = sk->sk_timer.expires;
-        } else {
-                timer_active    = 0;
-                timer_expires = jiffies;
-        }
-
+	data.laddr = inet->inet_rcv_saddr;
+	data.raddr = inet->inet_daddr;
+	data.lport = ntohs(inet->inet_sport);
+	data.rport = ntohs(inet->inet_dport);
 #if (KERNEL_CENTEVERSION > 415)
-	state = inet_sk_state_load(sk);
+	data.state = inet_sk_state_load(sk);
 #else
-	state = sk_state_load(sk);
+	data.state = sk_state_load(sk);
 #endif
+	data.cwnd = tp->snd_cwnd * tp->mss_cache;
+	data.rwnd = tp->rcv_wnd;
+	data.swnd = tp->snd_wnd;
+	data.mss = tp->advmss;
+	data.insegs = tp->segs_in;
+	data.outsegs = tp->segs_out;
+	data.retranssegs = tp->total_retrans;
+	data.rto = jiffies_to_clock_t(icsk->icsk_rto);
+	data.rtt = tp->srtt_us;
+	data.suna = tp->snd_nxt - tp->snd_una;
+	data.unsent = tp->write_seq - tp->snd_nxt;
+	data.inbytes = tp->bytes_received;
+	data.outbytes = tp->bytes_acked;
 
-        if (state == TCP_LISTEN)
-                rx_queue = sk->sk_ack_backlog;
-        else
-                /* Because we don't lock the socket,
-                 * we might find a transient negative value.
-                 */
-                rx_queue = max_t(int, tp->rcv_nxt - tp->copied_seq, 0);
+	if (data.state == TCP_LISTEN) {
+		data.rxqueue = sk->sk_ack_backlog;
+	} else {
+		/* Because we don't lock the socket,
+		 * we might find a transient negative value.
+		 */
+		data.rxqueue = max_t(int, tp->rcv_nxt - tp->copied_seq, 0);
+	}
 
-	record_ipv4_route(f, src, srcp, dest, destp, state,
-	    tp->snd_cwnd * tp->mss_cache, tp->rcv_wnd, tp->snd_wnd,
-	    tp->advmss, tp->bytes_received, tp->segs_in, tp->bytes_acked,
-	    tp->segs_out, tp->total_retrans, jiffies_to_clock_t(icsk->icsk_rto),
-	    tp->srtt_us, tp->write_seq - tp->pushed_seq,
-	    tp->pushed_seq - tp->snd_una);
+	record_ipv4_conn(f, &data);
 }
 
-
 static void get_timewait4_sock(const struct inet_timewait_sock *tw,
-                               struct seq_file *f)
+			       struct seq_file *f)
 {
-        __be32 dest, src;
-        __u16 destp, srcp;
+	struct connstat_data data = { 0 };
 
-        dest  = tw->tw_daddr;
-        src   = tw->tw_rcv_saddr;
-        destp = ntohs(tw->tw_dport);
-        srcp  = ntohs(tw->tw_sport);
+	data.laddr = tw->tw_rcv_saddr;
+	data.raddr = tw->tw_daddr;
+	data.lport = ntohs(tw->tw_sport);
+	data.rport = ntohs(tw->tw_dport);
+	data.state = tw->tw_substate;
 
-	record_ipv4_route(f, src, srcp, dest, destp, tw->tw_substate, 0, 0,
-	    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	record_ipv4_conn(f, &data);
 }
 
 #define TMPSZ 150
@@ -147,29 +146,29 @@ static int connstat_seq_show(struct seq_file *seq, void *v)
 {
 	struct sock *sk = v;
 
-        seq_setwidth(seq, TMPSZ - 1);
-        if (v == SEQ_START_TOKEN) {
-		seq_puts(seq,
-		    "laddr,"
-		    "lport,"
-		    "raddr,"
-		    "rport,"
-		    "state,"
-		    "inbytes,"
-		    "insegs,"
-		    "outbytes,"
-		    "outsegs,"
-		    "retranssegs,"
-		    "suna,"
-		    "unsent,"
-		    "swnd,"
-		    "cwnd,"
-		    "rwnd,"
-		    "mss,"
-		    "rto,"
-		    "rtt");
-                goto out;
-        }
+	seq_setwidth(seq, TMPSZ - 1);
+	if (v == SEQ_START_TOKEN) {
+		seq_puts(seq, "laddr,"
+			      "lport,"
+			      "raddr,"
+			      "rport,"
+			      "state,"
+			      "inbytes,"
+			      "insegs,"
+			      "outbytes,"
+			      "outsegs,"
+			      "retranssegs,"
+			      "suna,"
+			      "unsent,"
+			      "swnd,"
+			      "cwnd,"
+			      "rwnd,"
+			      "mss,"
+			      "rto,"
+			      "rtt,"
+			      "rxqueue");
+		goto out;
+	}
 
 	if (sk->sk_state == TCP_TIME_WAIT)
 		get_timewait4_sock(v, seq);
@@ -178,8 +177,8 @@ static int connstat_seq_show(struct seq_file *seq, void *v)
 	else
 		get_tcp4_sock(v, seq);
 out:
-        seq_pad(seq, '\n');
-        return 0;
+	seq_pad(seq, '\n');
+	return 0;
 }
 
 /*
@@ -190,51 +189,52 @@ out:
 #if (KERNEL_CENTEVERSION > 415)
 
 static const struct seq_operations connstat_seq_ops = {
-        .show           = connstat_seq_show,
-        .start          = tcp_seq_start,
-        .next           = tcp_seq_next,
-        .stop           = tcp_seq_stop,
+	.show = connstat_seq_show,
+	.start = tcp_seq_start,
+	.next = tcp_seq_next,
+	.stop = tcp_seq_stop,
 };
 
 static struct tcp_seq_afinfo connstat_seq_afinfo = {
-        .family         = AF_INET,
+	.family = AF_INET,
 };
 
 static int __net_init connstat_proc_init_net(struct net *net)
 {
-        if (!proc_create_net_data("stats_tcp", 0444, net->proc_net, &connstat_seq_ops,
-                        sizeof(struct tcp_iter_state), &connstat_seq_afinfo))
-                return -ENOMEM;
-        return 0;
+	if (!proc_create_net_data(
+		    "stats_tcp", 0444, net->proc_net, &connstat_seq_ops,
+		    sizeof(struct tcp_iter_state), &connstat_seq_afinfo))
+		return -ENOMEM;
+	return 0;
 }
 
 static void __net_exit connstat_proc_exit_net(struct net *net)
 {
-        remove_proc_entry("stats_tcp", net->proc_net);
+	remove_proc_entry("stats_tcp", net->proc_net);
 }
 
 #else
 
 static const struct file_operations connstat_seq_fops = {
-        .owner   = THIS_MODULE,
-        .open    = tcp_seq_open,
-        .read    = seq_read,
-        .llseek  = seq_lseek,
-        .release = seq_release_net
+	.owner = THIS_MODULE,
+	.open = tcp_seq_open,
+	.read = seq_read,
+	.llseek = seq_lseek,
+	.release = seq_release_net
 };
 
 static struct tcp_seq_afinfo connstat_seq_afinfo = {
-        .name           = "stats_tcp",
+	.name           = "stats_tcp",
 	.family         = AF_INET,
-        .seq_fops       = &connstat_seq_fops,
-        .seq_ops        = {
-                .show           = connstat_seq_show,
+	.seq_fops       = &connstat_seq_fops,
+	.seq_ops        = {
+		.show           = connstat_seq_show,
         },
 };
 
 static int __net_init connstat_proc_init_net(struct net *net)
 {
-        return tcp_proc_register(net, &connstat_seq_afinfo);
+	return tcp_proc_register(net, &connstat_seq_afinfo);
 }
 
 static void __net_exit connstat_proc_exit_net(struct net *net)
@@ -245,10 +245,9 @@ static void __net_exit connstat_proc_exit_net(struct net *net)
 #endif
 
 static struct pernet_operations connstat_net_ops = {
-        .init = connstat_proc_init_net,
-        .exit = connstat_proc_exit_net,
+	.init = connstat_proc_init_net,
+	.exit = connstat_proc_exit_net,
 };
-
 
 int connstat_init_module(void)
 {

--- a/usr/cmd/connstat
+++ b/usr/cmd/connstat
@@ -31,7 +31,7 @@ class ParsePositiveIntegerAction(argparse.Action):
             else:
                 dest_string = 'interval'
 
-            raise ValueError(dest_string + ' must be > 0')
+            sys.exit(dest_string + ' must be > 0')
         setattr(namespace, self.dest, values)
 
 
@@ -42,12 +42,16 @@ class Field(Enum):
         return self.__index
 
     @property
-    def print_name(self):
-        return self.__name
-
-    @property
     def print_width(self):
         return self.__print_width
+
+    @property
+    def kernel_supports(self):
+        return self.__kernel_supports
+
+    @kernel_supports.setter
+    def kernel_supports(self, supports):
+        self.__kernel_supports = supports
 
     @property
     def filter(self):
@@ -57,30 +61,35 @@ class Field(Enum):
     def filter(self, filter):
         self.__filter = filter
 
-    def __init__(self, index, name, print_width, filter):
+    def __init__(self, index, print_width):
         self.__index = index
-        self.__name = name
         self.__print_width = print_width
-        self.__filter = filter
+        self.__kernel_supports = False
+        self.__filter = None
 
-    laddr = 0, 'laddr', 15, None
-    lport = 1, 'lport', 6, None
-    raddr = 2, 'raddr', 15, None
-    rport = 3, 'rport', 6, None
-    state = 4, 'state', 12, None
-    inbytes = 5, 'inbytes', 11, None
-    insegs = 6, 'insegs', 11, None
-    outbytes = 7, 'outbytes', 11, None
-    outsegs = 8, 'outsegs', 11, None
-    retranssegs = 9, 'retranssegs', 12, None
-    suna = 10, 'suna', 11, None
-    unsent = 11, 'unsent', 11, None
-    swnd = 12, 'swnd', 11, None
-    cwnd = 13, 'cwnd', 11, None
-    rwnd = 14, 'rwnd', 11, None
-    mss = 15, 'mss', 6, None
-    rto = 16, 'rto', 8, None
-    rtt = 17, 'rtt', 8, None
+    #
+    # The names of the following enums must match the strings in the header of
+    # the output of /proc/net/stats_tcp.
+    #
+    laddr = 0, 15
+    lport = 1, 6
+    raddr = 2, 15
+    rport = 3, 6
+    state = 4, 12
+    inbytes = 5, 11
+    insegs = 6, 11
+    outbytes = 7, 11
+    outsegs = 8, 11
+    retranssegs = 9, 12
+    suna = 10, 11
+    unsent = 11, 11
+    swnd = 12, 11
+    cwnd = 13, 11
+    rwnd = 14, 11
+    mss = 15, 6
+    rto = 16, 8
+    rtt = 17, 8
+    rxqueue = 18, 11
 
 
 output_fields = [Field.laddr, Field.lport, Field.raddr,
@@ -110,8 +119,19 @@ def loopback_skip(line_str_list):
         return False
     ip1 = line_str_list[Field.laddr.index].split('.')
     if (ip1[0] == '127'):
-            return True
+        return True
     return False
+
+
+def discover_supported_fields():
+    with open('/proc/net/stats_tcp') as f:
+        kernel_fields = f.readline().strip().split(',')
+    #
+    # Iterate over all of the fields in the header and keep track of those
+    # that were read in the Field enum.
+    #
+    for f in kernel_fields:
+        Field[f].kernel_supports = True
 
 
 #
@@ -163,6 +183,7 @@ def connstat_regurgitate():
 
     return table_str
 
+
 parser = argparse.ArgumentParser(prog='connstat')
 
 parser.add_argument('-c', '--count', action=ParsePositiveIntegerAction,
@@ -188,25 +209,37 @@ parser.add_argument('-T', '--timestamp', action='store', dest='TYPE',
 args = parser.parse_args()
 
 if args.parsable and args.FIELDS is None:
-    raise ValueError('parsable output requires \'-o\'')
+    sys.exit('parsable output requires \'-o\'')
 
 if args.parsable and args.FIELDS == 'all':
-    raise ValueError('\'-o all\' is invalid with parsable output')
+    sys.exit('\'-o all\' is invalid with parsable output')
 
 if args.count is not None:
     if args.SECONDS is None:
-        raise ValueError('interval must be specified if count is specified')
+        sys.exit('interval must be specified if count is specified')
     count_index = args.count
 
+lazy_load_module()
+discover_supported_fields()
+
 if args.FIELDS is not None:
+    field_names = set(item.name for item in Field)
     output_fields = []
     if args.FIELDS == 'all':
         for f in Field:
-            output_fields.append(f)
+            if f.kernel_supports:
+                output_fields.append(f)
     else:
         output_list = args.FIELDS.split(',')
         for item in output_list:
-            output_fields.append(Field[item])
+            if item not in field_names:
+                sys.exit('Unknown field: \'' + item + '\'')
+
+            field = Field[item]
+            if not field.kernel_supports:
+                sys.exit('This kernel does not support field \'' + item + '\'')
+            else:
+                output_fields.append(field)
 
 if args.established:
     Field.state.filter = 'ESTABLISHED'
@@ -219,21 +252,19 @@ if args.filter is not None:
 
 if args.parsable:
     if args.FIELDS is None:
-        raise ValueError('parsable output requires \'-o\'')
+        sys.exit('parsable output requires \'-o\'')
     if args.FIELDS == 'all':
-        raise ValueError('\'-o all\' is invalid with parsable output')
-
-lazy_load_module()
+        sys.exit('\'-o all\' is invalid with parsable output')
 
 while True:
     output = ""
-    if args.TYPE is 'u':
+    if args.TYPE == 'u':
         output += "= " + str(time.time()) + "\n"
-    elif args.TYPE is 'd':
+    elif args.TYPE == 'd':
         output += "= " + str(os.system("date")) + "\n"
 
     output += connstat_regurgitate()
-    print (output, end="")
+    print(output, end="")
     sys.stdout.flush()
 
     if args.SECONDS is None:
@@ -244,4 +275,7 @@ while True:
         if count_index == 0:
             break
 
-    time.sleep(args.SECONDS)
+    try:
+        time.sleep(args.SECONDS)
+    except KeyboardInterrupt:
+        exit(0)

--- a/usr/man/man1/connstat.1m
+++ b/usr/man/man1/connstat.1m
@@ -200,6 +200,8 @@ The size of the local TCP send window (the peer's receive window) at this
 instant.
 .It Sy unsent
 The number of unsent bytes in the local TCP transmit queue at this instant.
+.It Sy rxqueue
+The number of bytes in the connection's receive queue.
 .El
 .Sh EXIT STATUS
 The


### PR DESCRIPTION
This pull request addresses the following issues:
connstat suna column doesn't seem to represent send+unacknowledged data #17
connstat should gracefully handle keyboard interrupt #15
connstat command can't handle running on an older kernel #18
would like to display TCP receive queue size with connstat #20

This is a clean cherry-pick from the `master` branch.

The main bug being fixed (#17) is caused by the caller of
record_ipv4_route() passing in the last two arguments in the wrong
order.

In addition to this simple fix, in order to prevent a similar error in
the future, record_ipv4_route() (which is renamed to record_ipv4_conn())
now takes a pointer to a pameter structure instead of a large number of
arguments.

This change also applies LLVM code style to the kernel module source,
and adds a GitHub Action to check python lint using flake8.