### PR TITLE
missing newlines in the output of /proc/net/stats_tcp

### DIFF
--- a/module/src/connstat.c
+++ b/module/src/connstat.c
@@ -61,7 +61,7 @@ static void record_ipv4_conn(struct seq_file *f, struct connstat_data *data)
 
 	seq_printf(f,
 		   "%s,%u,%s,%u,%s,%llu,%u,%llu,%u,%u,"
-		   "%u,%u,%u,%u,%u,%u,%u,%u,%u",
+		   "%u,%u,%u,%u,%u,%u,%u,%u,%u\n",
 		   ipv4_ntop(data->laddr, laddr), data->lport,
 		   ipv4_ntop(data->raddr, raddr), data->rport,
 		   tcp_state_strings[data->state], data->inbytes, data->insegs,
@@ -163,7 +163,8 @@ static int connstat_seq_show(struct seq_file *seq, void *v)
 			      "mss,"
 			      "rto,"
 			      "rtt,"
-			      "rxqueue");
+			      "rxqueue"
+			      "\n");
 		goto out;
 	}
 


### PR DESCRIPTION
I tested this fix by building using `git linux-pkg ...` and installing on a VM. I ran the failing test:

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/20420/consoleFull

It's also been manually tested.

Before:
```
delphix@guild:~$ connstat
          laddr lport          raddr rport       state
```
After
```
root@guild:~# connstat
          laddr lport          raddr rport       state
        0.0.0.0  8415        0.0.0.0     0      LISTEN
        0.0.0.0  2049        0.0.0.0     0      LISTEN
        0.0.0.0   873        0.0.0.0     0      LISTEN
      127.0.0.1  8586        0.0.0.0     0      LISTEN
        0.0.0.0 38699        0.0.0.0     0      LISTEN
        0.0.0.0  5005        0.0.0.0     0      LISTEN
    10.43.53.83    80        0.0.0.0     0      LISTEN
     127.0.0.53    53        0.0.0.0     0      LISTEN
        0.0.0.0    22        0.0.0.0     0      LISTEN
        0.0.0.0  5432        0.0.0.0     0      LISTEN
        0.0.0.0  3260        0.0.0.0     0      LISTEN
    10.43.53.83 35414   172.16.105.4   389 ESTABLISHED
      127.0.0.1 52310      127.0.0.1  5432   TIME_WAIT
      127.0.0.1 52306      127.0.0.1  5432   TIME_WAIT
      127.0.0.1 52312      127.0.0.1  5432   TIME_WAIT
    10.43.53.83 35430   172.16.105.4   389   TIME_WAIT
      127.0.0.1 52308      127.0.0.1  5432   TIME_WAIT
    10.43.53.83 35432   172.16.105.4   389   TIME_WAIT
    10.43.53.83 35416   172.16.105.4   389 ESTABLISHED
    10.43.53.83    22 172.16.168.122 53803 ESTABLISHED
    10.43.53.83 35418   172.16.105.4   389 ESTABLISHED
```