### PR TITLE
compile with debug info

### DIFF
--- a/module/src/Makefile.in
+++ b/module/src/Makefile.in
@@ -16,7 +16,7 @@
 #
 
 obj-m += connstat.o
-ccflags-y := -DKERNEL_CENTEVERSION=@@KCENTEVERS@@
+ccflags-y := -DKERNEL_CENTEVERSION=@@KCENTEVERS@@ -g
 MODOPTS= -C /lib/modules/@@KVERS@@/build M=$(PWD)
 
 all:


### PR DESCRIPTION
Before:
```
$ ls -lh /lib/modules/5.3.0-26-generic/kernel/net/connstat/
-rw-r--r-- 1 root root 7.8K Jan 24 19:51 /lib/modules/5.3.0-26-generic/kernel/net/connstat/connstat.ko

$ sudo sdb
could not get debugging information for:
/lib/modules/5.3.0-26-generic/kernel/net/connstat/connstat.ko (libdwfl error: No DWARF information found)
sdb> addr connstat_init_module
sdb: addr: symbol not found: connstat_init_module
```

After:
```
$ ls -lh /lib/modules/5.3.0-26-generic/kernel/net/connstat/
-rw-r--r-- 1 root root 590K Jan 30 23:23 /lib/modules/5.3.0-26-generic/kernel/net/connstat/connstat.ko

$ sudo sdb
sdb> addr connstat_init_module
(int (*)(void))init_module+0x0 = 0xffffffffc0c28430
```