### PR TITLE
DLPX-72423 modules.dep.bin is being removed preventing kernel modules from being loaded

### DIFF
--- a/module/configure.sh
+++ b/module/configure.sh
@@ -31,5 +31,8 @@ sed "s/@@KVERS@@/$KVERS/g" \
 	debian/control.in >debian/control
 sed "s/@@KVERS@@/$KVERS/g" \
 	debian/install.in >debian/install
+sed "s/@@KVERS@@/$KVERS/g" \
+	debian/postinst.in >debian/postinst
+chmod 755 debian/postinst
 sed "s/@@KVERS@@/$KVERS/g; s/@@KCENTEVERS@@/$kcentevers/g" \
 	src/Makefile.in >src/Makefile

--- a/module/debian/postinst.in
+++ b/module/debian/postinst.in
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+depmod -a @@KVERS@@

--- a/usr/cmd/connstat
+++ b/usr/cmd/connstat
@@ -69,7 +69,7 @@ def lazy_load_module():
     if lsmod != 0:
         if not args.parsable:
             print("Loading connstat kernel module")
-        os.system("sudo depmod;sudo modprobe connstat")
+        os.system("sudo modprobe connstat")
 
 
 def initialize_fields():


### PR DESCRIPTION
This is caused because we have multiple parallel invocations of depmod at the same time, which are triggered by connstat. The real bug is with depmod that is not properly handling concurrent calls. That said, we have no reasons to call depmod at every invocation of connstat. I believe it is only necessary when we install the connstat kernel modules for the first time (which is already taken care of during image creation), and so was likely added during the initial prototyping of the package.

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4462/