### PR TITLE
DLPX-73253 [Backport of DLPX-72423 to 6.0.6.0] modules.dep.bin is being removed preventing kernel modules from being loaded

### DIFF
--- a/module/configure.sh
+++ b/module/configure.sh
@@ -31,5 +31,8 @@ sed "s/@@KVERS@@/$KVERS/g" \
 	debian/control.in >debian/control
 sed "s/@@KVERS@@/$KVERS/g" \
 	debian/install.in >debian/install
+sed "s/@@KVERS@@/$KVERS/g" \
+	debian/postinst.in >debian/postinst
+chmod 755 debian/postinst
 sed "s/@@KVERS@@/$KVERS/g; s/@@KCENTEVERS@@/$kcentevers/g" \
 	src/Makefile.in >src/Makefile

--- a/module/debian/postinst.in
+++ b/module/debian/postinst.in
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+depmod -a @@KVERS@@

--- a/usr/cmd/connstat
+++ b/usr/cmd/connstat
@@ -103,7 +103,7 @@ def lazy_load_module():
     if lsmod != 0:
         if not args.parsable:
             print("Loading connstat kernel module")
-        os.system("sudo depmod;sudo modprobe connstat")
+        os.system("sudo modprobe connstat")
 
 
 def filter_skip(line_str_list):


### PR DESCRIPTION
Clean cherry-pick of #28 

## Testing
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4488/